### PR TITLE
#56 Change compatible version of Python

### DIFF
--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -2,7 +2,7 @@
 
 ## Software
 
-- Python: 3.7+
+- Python: 3.7 to 3.11
 
 ## External Dependencies
 

--- a/docs/integration_resources/resources/usd.md
+++ b/docs/integration_resources/resources/usd.md
@@ -18,7 +18,7 @@ To start working with the USD API in Shift, please follow the following steps:
 | **Dependency**                                           | **Version**    |
 | -------------------------------------------------------- | -------------- |
 | [Python](https://www.python.org/download/releases/3.0/)  | 3.7 to 3.11    |
-| [USD](https://pypi.org/project/usd-core/)                | 21.8 or higher |
+| [USD](https://pypi.org/project/usd-core/)                | 23.02 or higher |
 
 <!-- ##Plugins
 

--- a/docs/integration_resources/resources/usd.md
+++ b/docs/integration_resources/resources/usd.md
@@ -17,7 +17,7 @@ To start working with the USD API in Shift, please follow the following steps:
 ## Dependencies
 | **Dependency**                                           | **Version**    |
 | -------------------------------------------------------- | -------------- |
-| [Python](https://www.python.org/download/releases/3.0/)  | 3.7 or higher  |
+| [Python](https://www.python.org/download/releases/3.0/)  | 3.7 to 3.11    |
 | [USD](https://pypi.org/project/usd-core/)                | 21.8 or higher |
 
 <!-- ##Plugins


### PR DESCRIPTION
## Issue
Closes #56

## Description
Shift is not currently compatible with Python 3.12.
We have to change the documentation to indicate that Shift and Shift catalogs are compatible from 3.7 to 3.11.
This specification is in the requirements page and in the USD page.