### PR TITLE
Image format testing

### DIFF
--- a/docs/reference/shift_catalogs/constants.md
+++ b/docs/reference/shift_catalogs/constants.md
@@ -6,7 +6,7 @@ A catalog to work with standard Python type objects.
 
 <figure style="width: 30%">
 	<img src="images/Bool.png" alt="Node UI">
-	<figcaption></figcaption>
+	<figcaption>Format across the documentation</figcaption>
 </figure>
 
 Operator used to define a boolean value.
@@ -27,9 +27,9 @@ Operator used to define a boolean value.
 ---
 ## Float
 
-<figure style="width: 30%">
-	<img src="images/Float.png" alt="Node UI">
-	<figcaption></figcaption>
+<figure style="width: 30%" markdown>
+      ![Node UI](images/Float.png)
+      <figcaption>Format with markdown</figcaption>
 </figure>
 
 Operator used to define a floating point number value.
@@ -50,10 +50,7 @@ Operator used to define a floating point number value.
 ---
 ## Integer
 
-<figure style="width: 30%">
-	<img src="images/Integer.png" alt="Node UI">
-	<figcaption></figcaption>
-</figure>
+<img src="images/Integer.png" alt="UI">
 
 Operator used to define an integer number value.
 


### PR DESCRIPTION
This PR includes 3 formats for images to test them live on the website. 

- The format we use across the documentation
- The format that includes markdwon 
- Raw image

If any of these work in the live documentation, the changes will be done to the rest of the images in the documentation 