### PR TITLE
#84 Fixing paths due to Folder restrucutre

### DIFF
--- a/docs/getting_started/basics/nesting_workflows.md
+++ b/docs/getting_started/basics/nesting_workflows.md
@@ -21,8 +21,8 @@ The `Workflow` node allows to embed the execution of a workflow inside another w
       <figcaption><b>Figure 2</b>: Nesting and executing a workflow in a Workflow node.</figcaption>
 </figure>
 
-To learn more about the `Workflow` node functionalities, please refer to the [`Workflow`](../../nodes/workflow) documentation.
+To learn more about the `Workflow` node functionalities, please refer to the [`Workflow`](../../reference/nodes/workflow) documentation.
 
 ### Workflows on External Processes
 
-When using the `Workflow` node, the execution of the workflow happens on the same Python process Shift is running in. However, it is also possible to execute a workflow in an external process running in a different Python interpreter. To do so, please refer to the [Workflow Process](../../nodes/workflow#workflowprocess-node) documentation.
+When using the `Workflow` node, the execution of the workflow happens on the same Python process Shift is running in. However, it is also possible to execute a workflow in an external process running in a different Python interpreter. To do so, please refer to the [Workflow Process](../../reference/nodes/workflow#workflowprocess-node) documentation.

--- a/docs/integration_resources/software/houdini.md
+++ b/docs/integration_resources/software/houdini.md
@@ -23,7 +23,7 @@ In Shift it is possible to launch the execution of a workflow via an application
 
 ## Catalogs
 
-Shift provides some catalogs with operators specific to work within Houdini. Most of these nodes are found in the [CreativeSoftware](../../reference/shift_catalogs/creativesoftware) catalog. 
+Shift provides some catalogs with operators specific to work within Houdini. Most of these nodes are found in the [CreativeSoftware](../../reference/catalogs/shift_catalogs/creativesoftware) catalog. 
 
 <!-- ### Examples
 This section is reserved to an example video of how to use Shift in Houdini.

--- a/docs/integration_resources/software/maya.md
+++ b/docs/integration_resources/software/maya.md
@@ -23,7 +23,7 @@ In Shift it is possible to launch the execution of a workflow via an application
 
 ## Catalogs
 
-Shift provides some catalogs with operators specific to work within Maya. Most of these nodes are found in the [CreativeSoftware](../../reference/shift_catalogs/creativesoftware) catalog. Additionally, Shift also comes with a specific USD catalog for [MayaUSD](../resources/USD/smayausd).
+Shift provides some catalogs with operators specific to work within Maya. Most of these nodes are found in the [CreativeSoftware](../../reference/catalogs/shift_catalogs/creativesoftware) catalog. Additionally, Shift also comes with a specific USD catalog for [MayaUSD](../resources/USD/smayausd).
 
 <!-- ### Examples
 This section is reserved to an example video of how to use Shift in Maya.

--- a/docs/integration_resources/software/nuke.md
+++ b/docs/integration_resources/software/nuke.md
@@ -79,7 +79,7 @@ The variable can be set in any environment to be able to execute Shift Workflows
 
 ## Catalogs
 
-Shift provides some catalogs with operators specific to work within Nuke. Most of these nodes are found in the [CreativeSoftware](../../reference/shift_catalogs/creativesoftware) catalog. 
+Shift provides some catalogs with operators specific to work within Nuke. Most of these nodes are found in the [CreativeSoftware](../../reference/catalogs/shift_catalogs/creativesoftware) catalog. 
 
 
 <!-- ### Examples

--- a/docs/reference/catalogs/catalogs.md
+++ b/docs/reference/catalogs/catalogs.md
@@ -7,11 +7,11 @@ Shift comes with six native catalogs that contain the necessary nodes to start b
 - [**Constants catalog**](shift_catalogs/constants): Provides operators to work with standard Python objects, such as booleans or strings.
 - [**Standard catalog**](shift_catalogs/standard): Provides operators to work with standard Python operations. It provides logic to perform [loop iterations](../nodes/iterator) and create [scriptable Python nodes](../nodes/python_script). It also includes operators to read/write JSON files, operate with lists, strings, dictionaries and more.
 - [**FileSystem catalog**](shift_catalogs/filesystem): Provides operators to work with the OS filesystem and environment variables. It includes operators to perform file & directory creation and manipulation and more.
-- [**Workflow catalog**](shift_catalogs/workflow): Provides operators to manage and nest Shift workflows. It includes operators to input and output data, store [variables](nodes/variable) and execute [sub-workflows](../nodes/workflow).
+- [**Workflow catalog**](shift_catalogs/workflow): Provides operators to manage and nest Shift workflows. It includes operators to input and output data, store [variables](../nodes/variable) and execute [sub-workflows](../nodes/workflow).
 - [**CreativeSoftware catalog**](shift_catalogs/creativesoftware): Provides operators to work with Digital Content Creation software. It includes operators for scene management, geometry handling, node graph manipulation and more, across popular DCC tools like Maya, Houdini, Blender, and Nuke.
 
 >[!NOTE]
-> Shift is fully integrated with USD and provides in-built catalogs and plugins. For more information about USD integration in Shift, please refer to the [USD](../../integration_resources/resources/usd) documentation.
+> Shift is fully integrated with USD and provides in-built catalogs and plugins. For more information about USD integration in Shift, please refer to the [USD](../../integration_resources/resources/USD/usd) documentation.
 
 >[!NOTE]
 > Shift also comes with a native catalog for Deadline. For more information about Shift's integration in Deadline and how to use this catalog, please refer to the [Deadline Integration](../../integration_resources/software/deadline) documentation.

--- a/docs/reference/developer_guide/developing_custom_catalogs.md
+++ b/docs/reference/developer_guide/developing_custom_catalogs.md
@@ -22,7 +22,7 @@ Custom catalogs are written in Python and include a global variable called `cata
 
 There are two ways of adding a custom catalog to Shift:
 
-- **As a User Catalog**: Use the [Catalog Manager](../catalogs#the-catalog-manager) to source the catalog file and add it to Shift. This catalog is saved in the user preferences.
+- **As a User Catalog**: Use the [Catalog Manager](../catalogs/catalogs#the-catalog-manager) to source the catalog file and add it to Shift. This catalog is saved in the user preferences.
 - **As an Environment Catalog**: Add the **path to the directory** containing the catalog file to the `SHIFT_CATALOG_PATH` environment variable. All files in this path containing a `catalog` object will be identified as custom catalogs and loaded by Shift.
 
 >[!WARNING]

--- a/docs/reference/nodes/conditional.md
+++ b/docs/reference/nodes/conditional.md
@@ -16,8 +16,8 @@ The *ConditionalEquals* node allows to compare if two values are equal. Dependin
 - **value2**: This plug of type Object is used as one of the values to compare.
 
 ### Outputs
-- **true**: This plug of type [Bool](../nodes#plugs) indicates if the compared values are equal. If that is the case (the value of this plug is `True`), the nodes connected to this plug will be executed.
-- **false**: This plug of type [Bool](../nodes#plugs) indicates if the compared values are not equal. If that is the case (the value of this plug is `True`), the nodes connected to this plug will be executed.
+- **true**: This plug of type [Bool](nodes#plugs) indicates if the compared values are equal. If that is the case (the value of this plug is `True`), the nodes connected to this plug will be executed.
+- **false**: This plug of type [Bool](nodes#plugs) indicates if the compared values are not equal. If that is the case (the value of this plug is `True`), the nodes connected to this plug will be executed.
 
 In this example, we are comparing two `True` boolean values. The result of the ConditionalEquals evaluation is **true**, therefore, the branch connected to the *true* plug will be evaluated.
 <figure style="width:80%;" markdown>

--- a/docs/reference/nodes/iterator.md
+++ b/docs/reference/nodes/iterator.md
@@ -16,11 +16,11 @@ This node forces the execution of the subgraph composed by the nodes following t
 
 ### Inputs
 
-- **inValues** : This plug of type [Instance](../nodes#plugs) expects an iterable Python object, such as lists, dictionaries, sets or tuples. The number of elements of the iterable object will determine the number of loops the *Iterator* node will execute.
+- **inValues** : This plug of type [Instance](nodes#plugs) expects an iterable Python object, such as lists, dictionaries, sets or tuples. The number of elements of the iterable object will determine the number of loops the *Iterator* node will execute.
 
 ### Outputs
 
-- **outValue**: This plug of type [Instance](../nodes#plugs) will output one value of the input iterable object corresponding to the current iteration. This means that the output of this plug will change dynamically for each loop the iteration Node executes. 
+- **outValue**: This plug of type [Instance](nodes#plugs) will output one value of the input iterable object corresponding to the current iteration. This means that the output of this plug will change dynamically for each loop the iteration Node executes. 
 
 
 ## IteratorEnd Node
@@ -44,7 +44,7 @@ The *ListAccumulator* node allows to accumulate the result of each iteration of 
 
 ### Inputs
 
-- **inList**: This plug of type [Instance](../nodes#plugs) expects the list where the values will be accumulated into.
+- **inList**: This plug of type [Instance](nodes#plugs) expects the list where the values will be accumulated into.
 
 Custom plugs should be added to the *ListAccumulator* plug to define which elements should be accumulated in the list. There is no limit of custom input plugs that can be added. The elements will be appended in the same order they were created in the node. 
 
@@ -53,7 +53,7 @@ Custom plugs should be added to the *ListAccumulator* plug to define which eleme
 
 ### Outputs
 
-- **outList**: This plug of type [List](../nodes#plugs) will output a copy of the list with the new appended values.
+- **outList**: This plug of type [List](nodes#plugs) will output a copy of the list with the new appended values.
 
 <!-- ### Examples
 TODO: #62

--- a/docs/reference/nodes/nodes.md
+++ b/docs/reference/nodes/nodes.md
@@ -11,7 +11,7 @@ Five main interface elements compose the node: the node's name, the operator typ
     <figcaption><b>Figure 1</b>: Overview of the Node elements.</figcaption>
 </figure>
 
-* **Node Name**: Defines the name of the node. On creation, the name of the node is the name of the operator with an enumerated suffix. The name of the node can be changed through the [*Inspector Widget*](../getting_started/basics/ui_overview#the-inspector).
+* **Node Name**: Defines the name of the node. On creation, the name of the node is the name of the operator with an enumerated suffix. The name of the node can be changed through the [*Inspector Widget*](../../getting_started/basics/ui_overview#the-inspector).
 * **Operator Type**: The associated operator to the node. It determines the native plugs of the node.
 * **Trigger Plugs**: The trigger plugs (`>>>`) are plugs meant to define the node's position in the execution graph. They do not pass any data. If the node has other input or output plugs connected to another node, the trigger plugs do not need to be connected; otherwise, it is recommended to connect these plugs to indicate when the node needs to get computed.
 * **Input and Output Plugs**: Input and output plugs define the incoming data required by the operator and the resulting data after it is computed. 
@@ -22,7 +22,7 @@ Five main interface elements compose the node: the node's name, the operator typ
 To read further information about a node, `Right-Click` on the node and `Click` on the *Help* option. This will prompt a dialog with the following information:
 
 * The node's name.
-* The operator type and the [Catalog](../reference/catalogs/catalogs) it belongs to.
+* The operator type and the [Catalog](../../reference/catalogs/catalogs) it belongs to.
 * The operator description.
 * The input and output plugs with their corresponding plug types.
 
@@ -33,7 +33,7 @@ To read further information about a node, `Right-Click` on the node and `Click` 
 
 ## Plugs
 
-Plugs define the input and output data of the nodes. Data values can be set through the [*Inspector Widget*](../getting_started/basics/ui_overview#the-inspector) or by connecting plugs, which allows nodes to pass data from one to another. The kind of data compatible with a plug is defined by the plug type.
+Plugs define the input and output data of the nodes. Data values can be set through the [*Inspector Widget*](../../getting_started/basics/ui_overview#the-inspector) or by connecting plugs, which allows nodes to pass data from one to another. The kind of data compatible with a plug is defined by the plug type.
 
 **Plug Types**
 

--- a/docs/reference/nodes/python_script.md
+++ b/docs/reference/nodes/python_script.md
@@ -11,13 +11,13 @@ External Python libraries can be imported to enhance the capabilities of the *Py
 
 ### Inputs
 
-- **Script**: This plug of type [Code](../nodes#plugs) defines the logic of the *PythonScript* node. On the [Inspector](../../getting_started/basics/ui_overview#the-inspector), this plug provides a script editor for Python to write the block of code to be executed.
+- **Script**: This plug of type [Code](nodes#plugs) defines the logic of the *PythonScript* node. On the [Inspector](../../getting_started/basics/ui_overview#the-inspector), this plug provides a script editor for Python to write the block of code to be executed.
 
 The *PythonScript* node allows for any type of custom plugs too. Custom input plugs can receive data from other nodes that can be imported into the code by just using the plug name as a variable.
 
 ### Outputs
 
-- **Output**: This plug of type [Object](../nodes#plugs) outputs the result of the logic executed by the *PythonScript*.  Assign the value to output to a variable named `output` (the plug's name).
+- **Output**: This plug of type [Object](nodes#plugs) outputs the result of the logic executed by the *PythonScript*.  Assign the value to output to a variable named `output` (the plug's name).
 
 If outputting several values is needed, new output plugs of any type, including Instance plugs, can be added to the node. All custom outputs can be used the same way as the default output plug to return any data from the Python script execution.
 

--- a/docs/reference/nodes/workflow.md
+++ b/docs/reference/nodes/workflow.md
@@ -23,7 +23,7 @@ When double-clicking on a *Workflow* node, the referenced workflow will be opene
 
 ### Inputs
 
-- **File**: This plug of type [FileIn](../nodes#plugs) is used to reference the workflow file (*.sft* extension) that will be executed by the node. When the `file` plug content is set, the node will automatically update by creating the input and output plugs corresponding to the sourced workflow inputs and outputs.
+- **File**: This plug of type [FileIn](/nodes#plugs) is used to reference the workflow file (*.sft* extension) that will be executed by the node. When the `file` plug content is set, the node will automatically update by creating the input and output plugs corresponding to the sourced workflow inputs and outputs.
 
 ## WorkflowProcess Node
 
@@ -45,8 +45,8 @@ The available Python interpreters to run the external workflow with will depend 
 > **SHIFT_PROCESS_MAYA** : *"<MAYA INSTALLATION FOLDER>/bin/mayapy.exe"*
 
 ### Inputs
-- **File**: This plug of type [FileIn](../nodes#plugs) is used to reference the workflow file (*.sft* extension) that will be executed by the node. When the `file` plug content is set, the node will automatically update by creating the input and output plugs corresponding to the sourced workflow inputs and outputs.
-- **DCC**: This plug of type [Enum](../nodes#plugs) determines the Python interpreter to be used for the execution of the referenced workflow.
+- **File**: This plug of type [FileIn](/nodes#plugs) is used to reference the workflow file (*.sft* extension) that will be executed by the node. When the `file` plug content is set, the node will automatically update by creating the input and output plugs corresponding to the sourced workflow inputs and outputs.
+- **DCC**: This plug of type [Enum](/nodes#plugs) determines the Python interpreter to be used for the execution of the referenced workflow.
 
 >[!NOTE]
 > It is possible to define a "Workflow Workspace" by setting the path to a directory in the `SHIFT_PATH_WORKFLOWS` environment variable. All workflows placed in the folders specified in the environment variable will use a relative filepaths when referenced in a *Workflow* or *WorkflowProcess* node. 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -17,7 +17,7 @@ The *Nodes Outliner* helps the user to visualise the list of operators in the wo
 
 ### The Variables Browser
 
-The *Variables Browser* allows users to parse the workflow variables currently set and check their content. This is especially helpful in large workflows where it is easy to lose track of which nodes were previously executed. This plugin also allows to delete specific workflow variables set while working on a workflow. To do that `Right-click` on the variable entry to delete and select the *Delete* option. For more info on workflow variables please check out the section about [Variable Nodes](nodes/variable)
+The *Variables Browser* allows users to parse the workflow variables currently set and check their content. This is especially helpful in large workflows where it is easy to lose track of which nodes were previously executed. This plugin also allows to delete specific workflow variables set while working on a workflow. To do that `Right-click` on the variable entry to delete and select the *Delete* option. For more info on workflow variables please check out the section about [Variable Nodes](nodes/variable).
 
 <figure>
       <img src="images/variables_browser_plugin.gif" alt="UI">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,7 +131,7 @@ nav:
       - Developing Plugins:     reference/developer_guide/developing_custom_plugins.md
       - Shift Python API:       reference/developer_guide/api.md
   - Integrations & Resources:
-    - integration_resources/integrations_resources.md
+    - Integrations & Resources:   integration_resources/integrations_resources.md
     - Software Platforms:
       - Maya:                     integration_resources/software/maya.md
       - Houdini:                  integration_resources/software/houdini.md


### PR DESCRIPTION
## Issue
This is a continuation of #84 after testing the changes live on the webpage

## Description
This PR addresses missed paths not pointing to the right page due to the folder restructure. 
It also addresses some other paths that were not working before the folder restructure.
Finally, it adds a name to the page for integrations and resources.
