### PR TITLE
Added dependencies to Nuke ShiftWorkflow node.

### DIFF
--- a/docs/integration_resources/software/nuke.md
+++ b/docs/integration_resources/software/nuke.md
@@ -86,7 +86,8 @@ You can use relative paths if you use the **SHIFT_PATH_WORKFLOWS** environment v
 
 ### External Dependencies
 
-In order to use the ShiftWorkflow node for Nuke, the following Python modules are needed:
+In order to work with image data using the ShiftWorkflow node for Nuke, the following Python modules are needed:
+
 
 > [!NOTE = Dependencies]
 >

--- a/docs/integration_resources/software/nuke.md
+++ b/docs/integration_resources/software/nuke.md
@@ -82,7 +82,17 @@ In the Shiftworkflow node, a Shift workflow can be selected to load it into the 
       <figcaption><b>Figure 3</b>: Main Propierties tab of ShiftWorkflow node.</figcaption>
 </figure>
 
-You can use relative paths if you use the **SHIFT_PATH_WORKFLOWS** env variable.
+You can use relative paths if you use the **SHIFT_PATH_WORKFLOWS** environment variable.
+
+### External Dependencies
+
+In order to use the ShiftWorkflow node for Nuke, the following Python modules are needed:
+
+> [!NOTE = Dependencies]
+>
+> - [OpenCV](https://pypi.org/project/opencv-python/): 4.7.0 or higher
+> - [Pillow](https://pypi.org/project/pillow/): 10.2.0 or higher
+>
 
 ### Shift Plugs to Nuke Knobs/Inputs
 


### PR DESCRIPTION
## Issue 
#112 

## Description
After going over the Nuke ShiftWorkflow node page, we realized that some dependencies needed to run this node were not clearly listed on the page. 
We are adding them now. 

![image](https://github.com/user-attachments/assets/cb3e27b5-e796-4575-ad7e-9fb7a82df304)
